### PR TITLE
Proxy Alpaca orders via backend

### DIFF
--- a/Backend/.env
+++ b/Backend/.env
@@ -1,0 +1,12 @@
+# === ACTIVE (Paper) ===
+ALPACA_API_KEY=PKN4ICO3WECXSLDGXCHC
+ALPACA_SECRET_KEY=PwJAEwLnLnsf7qAVvFutE8VIMgsAgvi7PMkMcCca
+ALPACA_BASE_URL=https://paper-api.alpaca.markets
+ALPACA_DATA_URL=https://data.alpaca.markets/v1beta2
+
+# === OPTIONAL (Live) ===
+ALPACA_LIVE_API_KEY=AKP4CYCLABN0QHC7GVH4
+ALPACA_LIVE_SECRET_KEY=PwJAEwLnLnsf7qAVvFutE8VIMgsAgvi7PMkMcCca
+ALPACA_LIVE_BASE_URL=https://api.alpaca.markets
+
+PORT=3000

--- a/Backend/lib/alpaca.js
+++ b/Backend/lib/alpaca.js
@@ -1,0 +1,26 @@
+const axios = require('axios');
+
+const {
+  ALPACA_API_KEY,
+  ALPACA_SECRET_KEY,
+  ALPACA_BASE_URL = 'https://paper-api.alpaca.markets',
+} = process.env;
+
+if (!ALPACA_API_KEY || !ALPACA_SECRET_KEY) {
+  throw new Error('Missing Alpaca API credentials. Check Backend/.env');
+}
+
+const base = (ALPACA_BASE_URL || '').replace(/\/+$/, '');
+const alpaca = axios.create({
+  baseURL: `${base}/v2`, // single source of /v2 truth
+  headers: {
+    'APCA-API-KEY-ID': ALPACA_API_KEY,
+    'APCA-API-SECRET-KEY': ALPACA_SECRET_KEY,
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+  },
+  timeout: 15000,
+  validateStatus: () => true,
+});
+
+module.exports = { alpaca };

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "axios": "^1.6.8",
     "dotenv": "^16.0.3",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "cors": "^2.8.5"
   }
 }

--- a/Backend/routes/health.js
+++ b/Backend/routes/health.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const { alpaca } = require('../lib/alpaca');
+const router = express.Router();
+
+router.get('/ping', (req, res) => res.json({ status: 'ok' }));
+
+router.get('/alpaca/ping', async (req, res) => {
+  try {
+    const r = await alpaca.get('/account');
+    if (r.status >= 400) return res.status(r.status).json({ ok:false, status:r.status, data:r.data });
+    return res.json({ ok:true, account_id: r.data?.id, status: r.data?.status });
+  } catch (e) {
+    return res.status(500).json({ ok:false, message: e?.message || String(e) });
+  }
+});
+
+module.exports = { router };

--- a/Backend/routes/orders.js
+++ b/Backend/routes/orders.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const { alpaca } = require('../lib/alpaca');
+const router = express.Router();
+
+function toAlpacaOrderSymbol(sym) {
+  if (!sym) return sym;
+  if (sym.includes('/')) return sym;
+  if (sym.endsWith('USD') && sym.length > 3) return `${sym.slice(0, -3)}/USD`;
+  return sym;
+}
+
+// GET /api/orders/open?symbol=BTCUSD
+router.get('/orders/open', async (req, res) => {
+  try {
+    const raw = (req.query.symbol || '').trim();
+    if (!raw) return res.status(400).json({ error: 'Missing required query param: symbol' });
+
+    const symbol = toAlpacaOrderSymbol(raw);
+    const resp = await alpaca.get('/orders', {
+      params: { status: 'open', symbols: symbol, nested: false, limit: 200 },
+    });
+
+    if (resp.status >= 400) {
+      return res.status(resp.status).json({
+        error: 'Alpaca orders request failed',
+        status: resp.status,
+        data: resp.data,
+      });
+    }
+
+    const list = Array.isArray(resp.data) ? resp.data : (resp.data?.orders ?? []);
+    const filtered = Array.isArray(list) ? list.filter(o => o?.symbol === symbol) : [];
+    return res.json(filtered);
+  } catch (err) {
+    return res.status(500).json({
+      error: 'Backend error fetching open orders',
+      message: err?.message || String(err),
+    });
+  }
+});
+
+module.exports = { router };


### PR DESCRIPTION
## Summary
- add centralized Alpaca axios client and .env with provided paper/live keys
- expose /api/ping, /api/alpaca/ping, and /api/orders/open with symbol normalization
- route frontend `getOpenOrders` through backend and ensure it always returns an array

## Testing
- `curl -s http://localhost:3000/api/ping`
- `curl -s http://localhost:3000/api/alpaca/ping`
- `curl -s "http://localhost:3000/api/orders/open?symbol=BTCUSD"`


------
https://chatgpt.com/codex/tasks/task_e_689a3412cc4883258d53c8e24cca3d97