### PR TITLE
Route Alpaca calls through backend

### DIFF
--- a/Backend/index.js
+++ b/Backend/index.js
@@ -3,6 +3,7 @@ const express = require('express');
 const cors = require('cors');
 
 const { router: healthRouter } = require('./routes/health');
+const { router: positionsRouter } = require('./routes/positions');
 const { router: ordersRouter } = require('./routes/orders');
 
 const app = express();
@@ -10,13 +11,16 @@ app.use(cors());
 app.use(express.json());
 
 app.use('/api', healthRouter);
+app.use('/api', positionsRouter);
 app.use('/api', ordersRouter);
 
 // final error guard
 app.use((err, req, res, next) => {
   console.error('Unhandled error:', err);
-  res.status(500).json({ error: 'Unhandled server error', message: err?.message || String(err) });
+  res
+    .status(500)
+    .json({ error: 'Unhandled server error', message: err?.message || String(err) });
 });
 
 const port = process.env.PORT || 3000;
-app.listen(port, () => console.log(`Backend listening on :${port}`));
+app.listen(port, () => console.log(`[backend] listening on :${port}`));

--- a/Backend/routes/health.js
+++ b/Backend/routes/health.js
@@ -7,10 +7,25 @@ router.get('/ping', (req, res) => res.json({ status: 'ok' }));
 router.get('/alpaca/ping', async (req, res) => {
   try {
     const r = await alpaca.get('/account');
-    if (r.status >= 400) return res.status(r.status).json({ ok:false, status:r.status, data:r.data });
-    return res.json({ ok:true, account_id: r.data?.id, status: r.data?.status });
+    if (r.status >= 400) {
+      return res
+        .status(r.status)
+        .json({ ok: false, status: r.status, data: r.data });
+    }
+    return res.json({ ok: true, account_id: r.data?.id, status: r.data?.status });
   } catch (e) {
-    return res.status(500).json({ ok:false, message: e?.message || String(e) });
+    return res.status(500).json({ ok: false, message: e?.message || String(e) });
+  }
+});
+
+router.get('/alpaca/account', async (req, res) => {
+  try {
+    const r = await alpaca.get('/account');
+    return res.status(r.status).json(r.data);
+  } catch (e) {
+    return res
+      .status(500)
+      .json({ error: 'Backend error fetching account', message: e?.message || String(e) });
   }
 });
 

--- a/Backend/routes/orders.js
+++ b/Backend/routes/orders.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { alpaca } = require('../lib/alpaca');
+
 const router = express.Router();
 
 function toAlpacaOrderSymbol(sym) {
@@ -21,15 +22,13 @@ router.get('/orders/open', async (req, res) => {
     });
 
     if (resp.status >= 400) {
-      return res.status(resp.status).json({
-        error: 'Alpaca orders request failed',
-        status: resp.status,
-        data: resp.data,
-      });
+      return res
+        .status(resp.status)
+        .json({ error: 'Alpaca orders request failed', status: resp.status, data: resp.data });
     }
 
-    const list = Array.isArray(resp.data) ? resp.data : (resp.data?.orders ?? []);
-    const filtered = Array.isArray(list) ? list.filter(o => o?.symbol === symbol) : [];
+    const list = Array.isArray(resp.data) ? resp.data : resp.data?.orders ?? [];
+    const filtered = Array.isArray(list) ? list.filter((o) => o?.symbol === symbol) : [];
     return res.json(filtered);
   } catch (err) {
     return res.status(500).json({
@@ -39,4 +38,61 @@ router.get('/orders/open', async (req, res) => {
   }
 });
 
+// POST /api/orders
+router.post('/orders', async (req, res) => {
+  try {
+    const order = req.body || {};
+    if (!order.symbol) {
+      return res.status(400).json({ error: 'Missing required field: symbol' });
+    }
+    const payload = { ...order, symbol: toAlpacaOrderSymbol(order.symbol) };
+    const resp = await alpaca.post('/orders', payload);
+    return res.status(resp.status).json(resp.data);
+  } catch (err) {
+    return res
+      .status(500)
+      .json({ error: 'Backend error placing order', message: err?.message || String(err) });
+  }
+});
+
+// GET /api/orders/:id
+router.get('/orders/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const resp = await alpaca.get(`/orders/${id}`);
+    return res.status(resp.status).json(resp.data);
+  } catch (err) {
+    return res
+      .status(500)
+      .json({ error: 'Backend error fetching order', message: err?.message || String(err) });
+  }
+});
+
+// POST /api/orders/limit-sell
+router.post('/orders/limit-sell', async (req, res) => {
+  try {
+    const { symbol, qty, limit_price } = req.body || {};
+    if (!symbol || !qty || !limit_price) {
+      return res
+        .status(400)
+        .json({ error: 'Missing required fields: symbol, qty, limit_price' });
+    }
+    const order = {
+      symbol: toAlpacaOrderSymbol(symbol),
+      qty,
+      side: 'sell',
+      type: 'limit',
+      time_in_force: 'gtc',
+      limit_price,
+    };
+    const resp = await alpaca.post('/orders', order);
+    return res.status(resp.status).json(resp.data);
+  } catch (err) {
+    return res
+      .status(500)
+      .json({ error: 'Backend error placing limit sell', message: err?.message || String(err) });
+  }
+});
+
 module.exports = { router };
+

--- a/Backend/routes/positions.js
+++ b/Backend/routes/positions.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const { alpaca } = require('../lib/alpaca');
+
+const router = express.Router();
+
+function toAlpacaOrderSymbol(sym) {
+  if (!sym) return sym;
+  if (sym.includes('/')) return sym;
+  if (sym.endsWith('USD') && sym.length > 3) return `${sym.slice(0, -3)}/USD`;
+  return sym;
+}
+
+router.get('/positions/:symbol', async (req, res) => {
+  try {
+    const raw = (req.params.symbol || '').trim();
+    if (!raw) return res.status(400).json({ error: 'Missing required param: symbol' });
+
+    const symbol = toAlpacaOrderSymbol(raw);
+    const resp = await alpaca.get(`/positions/${symbol}`);
+    if (resp.status === 404) return res.status(404).json(null);
+    return res.status(resp.status).json(resp.data);
+  } catch (err) {
+    return res
+      .status(500)
+      .json({ error: 'Backend error fetching position', message: err?.message || String(err) });
+  }
+});
+
+module.exports = { router };
+

--- a/Frontend/network.js
+++ b/Frontend/network.js
@@ -1,0 +1,45 @@
+const BACKEND_URL = process.env.EXPO_PUBLIC_BACKEND_URL || 'http://localhost:3000/api';
+
+async function parseJson(res) {
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { error: 'Invalid JSON', raw: text };
+  }
+}
+
+export async function fetchAccount() {
+  const res = await fetch(`${BACKEND_URL}/alpaca/account`);
+  return parseJson(res);
+}
+
+export async function getOpenOrders(symbol) {
+  const res = await fetch(`${BACKEND_URL}/orders/open?symbol=${encodeURIComponent(symbol)}`);
+  return parseJson(res);
+}
+
+export async function getPosition(symbol) {
+  const res = await fetch(`${BACKEND_URL}/positions/${encodeURIComponent(symbol)}`);
+  if (res.status === 404) return null;
+  return parseJson(res);
+}
+
+export async function placeOrder(order) {
+  const res = await fetch(`${BACKEND_URL}/orders`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(order),
+  });
+  return parseJson(res);
+}
+
+export async function placeLimitSell({ symbol, qty, limit_price }) {
+  const res = await fetch(`${BACKEND_URL}/orders/limit-sell`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ symbol, qty, limit_price }),
+  });
+  return parseJson(res);
+}
+


### PR DESCRIPTION
## Summary
- add backend routes for account, positions, order placement and limit sell
- proxy all Alpaca traffic through backend via new network helper
- remove API keys from React Native app and use backend-backed order helpers

## Testing
- `cd Backend && npm i`
- `cd Backend && npm start` *(fails: Domain forbidden)*
- `curl -s http://localhost:3000/api/ping`
- `curl -s http://localhost:3000/api/alpaca/ping` *(fails: Domain forbidden)*
- `cd ../Frontend && npm i`
- `cd ../Frontend && npm start` *(fails: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a4f0d84108325b384f247a7beed87